### PR TITLE
feat: add release promotion workflow

### DIFF
--- a/.github/workflows/promote-prerelease.yml
+++ b/.github/workflows/promote-prerelease.yml
@@ -1,0 +1,49 @@
+name: Promote Prerelease
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Find RC commit
+        id: find_rc
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Get the version from the release that triggered this workflow
+          VERSION="${{ github.event.release.tag_name }}"
+
+          # Find the latest RC for this version
+          RC_TAG=$(gh release list | grep "$VERSION-rc" | head -n 1 | awk '{print $1}')
+          if [ -z "$RC_TAG" ]; then
+            echo "No RC found for version $VERSION"
+            exit 1
+          fi
+
+          # Extract commit hash from RC tag
+          COMMIT_HASH=$(echo $RC_TAG | cut -d. -f3)
+          echo "Found RC commit: $COMMIT_HASH"
+          echo "commit_hash=$COMMIT_HASH" >> $GITHUB_OUTPUT
+
+      - name: Checkout RC commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.find_rc.outputs.commit_hash }}
+          fetch-depth: 0
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          args: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Tell GoReleaser to create a non-prerelease
+          SKIP_PRERELEASE: true

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -4,10 +4,25 @@ on:
   push:
     branches:
       - main
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  workflow_dispatch:
+    inputs:
+      version_increment:
+        description: 'Version increment type'
+        required: false
+        type: choice
+        options:
+          - major
+          - minor
+          - patch
+      commit_hash:
+        description: 'Specific commit hash to use (optional)'
+        required: false
+        type: string
+      skip_prerelease:
+        description: 'Skip prerelease flag and hash in filenames'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   release-candidate:
@@ -22,9 +37,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.22'
-
-      - name: Install jq
-        run: sudo apt-get install -y jq
 
       - name: Get and increment latest version
         id: version
@@ -47,8 +59,18 @@ jobs:
           MINOR=$(echo $VERSION | cut -d. -f2)
           PATCH=$(echo $VERSION | cut -d. -f3)
 
-          # Increment patch
-          PATCH=$((PATCH + 1))
+          # Increment based on input or default to patch
+          INCREMENT_TYPE="${{ github.event.inputs.version_increment }}"
+          if [ "$INCREMENT_TYPE" = "major" ]; then
+            MAJOR=$((MAJOR + 1))
+            MINOR=0
+            PATCH=0
+          elif [ "$INCREMENT_TYPE" = "minor" ]; then
+            MINOR=$((MINOR + 1))
+            PATCH=0
+          else
+            PATCH=$((PATCH + 1))
+          fi
 
           # Create new version
           NEW_VERSION="v${MAJOR}.${MINOR}.${PATCH}"
@@ -60,24 +82,33 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # Get short commit hash
-          COMMIT_HASH=$(git rev-parse --short HEAD)
+          # Get commit hash (either from input or github.sha)
+          COMMIT_HASH="${{ github.event.inputs.commit_hash || github.sha }}"
+          COMMIT_HASH=$(echo $COMMIT_HASH | cut -c1-7)  # Get short hash
 
-          # Create RC tag (using proper semver format)
-          RC_TAG="${{ steps.version.outputs.new_version }}-rc.${COMMIT_HASH}"
+          # Create tag based on skip_prerelease flag
+          SKIP_PRERELEASE="${{ github.event.inputs.skip_prerelease }}"
+          if [ "$SKIP_PRERELEASE" = "true" ]; then
+            TAG="${{ steps.version.outputs.new_version }}"
+            PRERELEASE_FLAG=""
+          else
+            TAG="${{ steps.version.outputs.new_version }}-rc.${COMMIT_HASH}"
+            PRERELEASE_FLAG="--prerelease"
+          fi
 
-          # Create prerelease
-          gh release create "$RC_TAG" \
-            --prerelease \
-            --title "Release Candidate $RC_TAG" \
-            --notes "Automated release candidate for commit $COMMIT_HASH"
+          # Create release
+          gh release create "$TAG" \
+            $PRERELEASE_FLAG \
+            --title "Release $TAG" \
+            --notes "Release for commit $COMMIT_HASH"
 
-          echo "rc_tag=$RC_TAG" >> $GITHUB_OUTPUT
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "commit_hash=$COMMIT_HASH" >> $GITHUB_OUTPUT
 
       - name: Checkout with tag
         uses: actions/checkout@v4
         with:
-          ref: ${{ steps.create_rc.outputs.rc_tag }}
+          ref: ${{ steps.create_rc.outputs.tag }}
           fetch-depth: 0
 
       - name: Run GoReleaser
@@ -86,9 +117,12 @@ jobs:
           args: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Add skip_prerelease flag to GoReleaser if needed
+          SKIP_PRERELEASE: ${{ github.event.inputs.skip_prerelease }}
 
       - name: Ensure prerelease status
+        if: ${{ github.event.inputs.skip_prerelease != 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release edit "${{ steps.create_rc.outputs.rc_tag }}" --prerelease
+          gh release edit "${{ steps.create_rc.outputs.tag }}" --prerelease


### PR DESCRIPTION
## Overview
This PR introduces a new release promotion workflow and updates the release candidate workflow to support a more streamlined release process. The changes enable:
1. Automatic creation of RCs on main branch pushes
2. Manual RC creation with version control options
3. Automatic promotion of RCs to releases via GitHub UI

## Key Changes

### Release Candidate Workflow (`release-candidate.yml`)
- Added manual dispatch with options:
  - Version increment type (major/minor/patch)
  - Optional commit hash
  - Skip prerelease flag
- Improved commit hash handling using GitHub context
- Added support for non-RC releases via skip_prerelease flag
- Removed unnecessary concurrency settings

### New Promote Prerelease Workflow (`promote-prerelease.yml`)
- Triggers automatically when a release is created in GitHub UI
- Finds the latest RC for the release version
- Rebuilds the release from the RC's commit
- Ensures proper release artifacts and checksums

## Release Process Flow

1. **RC Creation (Automatic)**
   - Push to main branch creates RC with commit hash
   - Version is auto-incremented based on latest release

2. **RC Creation (Manual)**
   - Use workflow dispatch to create RC
   - Choose version increment type
   - Optionally specify commit hash
   - Optionally skip RC format for direct release

3. **Release Promotion**
   - Create release in GitHub UI using RC tag
   - Workflow automatically triggers
   - Rebuilds release from RC commit
   - Creates proper release artifacts

## Testing Process
To test the complete flow:

1. Create an RC:
   ```bash
   # Automatic RC on push to main
   git push origin main

   # Or manual RC with options
   # Use GitHub UI to trigger workflow with desired options
   ```

2. Promote RC to release:
   - Go to GitHub Releases
   - Click "Draft a new release"
   - Select the RC tag (e.g., `v0.1.4-rc.be10f32`)
   - Create release
   - Workflow will automatically rebuild as proper release
