### PR TITLE
feat: add Docker deployment configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,12 +18,17 @@ jobs:
         with:
           go-version: '1.22'
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCKERHUB_PAT: ${{ secrets.DOCKERHUB_PAT }}
+          GORELEASER_PRO_TOKEN: ${{ secrets.GORELEASER_PRO_TOKEN }}
           # Ensure we create a full release, not a prerelease
           GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
           GORELEASER_PREVIOUS_TAG: ${{ github.ref_name }}
@@ -34,3 +39,4 @@ jobs:
           echo "## Release Summary" >> $GITHUB_STEP_SUMMARY
           echo "- Version: ${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
           echo "- Release: https://github.com/${{ github.repository }}/releases/tag/${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Docker Image: rianfowler/project-orca:${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -83,3 +83,25 @@ changelog:
       - "^test:"
       - "^ci:"
       - "^chore:"
+
+docker:
+  - image_templates:
+      - "rianfowler/project-orca:{{ .Version }}"
+      - "rianfowler/project-orca:latest"
+    dockerfile: Dockerfile
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--platform=linux/arm64"
+    extra_files:
+      - LICENSE
+      - README.md
+
+dockerhub:
+  - username: "rianfowler"
+    secret_name: DOCKERHUB_PAT
+    images:
+      - rianfowler/project-orca
+    description: "Project Orca - A powerful CLI tool"
+    full_description:
+      from_file: DOCKER.md

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,54 @@
+# Project Orca Docker Image
+
+This document provides information about the official Docker image for Project Orca.
+
+## Quick Start
+
+Pull the latest image:
+```bash
+docker pull rianfowler/project-orca:latest
+```
+
+Run the container:
+```bash
+docker run --rm rianfowler/project-orca:latest ti --help
+```
+
+## Available Tags
+
+- `latest`: Latest stable release
+- `vX.Y.Z`: Specific version (e.g., `v1.0.0`)
+
+## Multi-Architecture Support
+
+The image is available for the following architectures:
+- linux/amd64
+- linux/arm64
+
+## Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `TITANIUM_CONFIG` | Path to configuration file | `/etc/titanium/config.yaml` |
+
+## Volume Mounts
+
+Common volume mounts:
+```bash
+# Mount a local config file
+docker run --rm -v $(pwd)/config.yaml:/etc/titanium/config.yaml rianfowler/project-orca:latest
+
+# Mount a data directory
+docker run --rm -v $(pwd)/data:/data rianfowler/project-orca:latest
+```
+
+## Building Locally
+
+To build the image locally:
+```bash
+docker build -t rianfowler/project-orca:local .
+```
+
+## Contributing
+
+To contribute to the Docker image, please refer to the [Dockerfile](Dockerfile) in the repository root.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,48 @@
+# Build stage
+FROM golang:1.22-alpine AS builder
+
+# Install build dependencies
+RUN apk add --no-cache git
+
+# Set working directory
+WORKDIR /build
+
+# Copy go mod files
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy source code
+COPY . .
+
+# Build the application
+RUN CGO_ENABLED=0 GOOS=linux go build -o /build/ti ./cmd/titanium/main.go
+
+# Final stage
+FROM alpine:3.19
+
+# Install runtime dependencies
+RUN apk add --no-cache ca-certificates tzdata
+
+# Create non-root user
+RUN adduser -D -g '' appuser
+
+# Set working directory
+WORKDIR /app
+
+# Copy binary from builder
+COPY --from=builder /build/ti /app/ti
+
+# Copy config template
+COPY config.yaml /etc/titanium/config.yaml
+
+# Set ownership
+RUN chown -R appuser:appuser /app /etc/titanium
+
+# Switch to non-root user
+USER appuser
+
+# Set entrypoint
+ENTRYPOINT ["/app/ti"]
+
+# Default command
+CMD ["--help"]


### PR DESCRIPTION
This PR adds Docker deployment support to the project, including:

- Add Docker and DockerHub configuration to GoReleaser
- Update release workflow with Docker build support
- Add DOCKER.md with comprehensive documentation
- Add multi-stage Dockerfile with security best practices

The Docker image will be published to `rianfowler/project-orca` on DockerHub with support for:
- Multi-arch builds (linux/amd64, linux/arm64)
- Versioned tags and latest tag
- Proper security practices (non-root user, minimal base image)

Closes #51